### PR TITLE
Fix find-doc-nits

### DIFF
--- a/util/find-doc-nits
+++ b/util/find-doc-nits
@@ -188,7 +188,7 @@ sub check()
     print "$id WARNING not WARNINGS section.\n"
         if $contents =~ /=head1 WARNING[^S]/;
     print "$id missing copyright\n"
-        if $contents !~ /Copyright .* The OpenSSL Project Authors/;
+        if $contents !~ /Copyright .*/;
     print "$id copyright not last\n"
         if $contents =~ /head1 COPYRIGHT.*=head/ms;
     print "$id head2 in All uppercase\n"


### PR DESCRIPTION
Current find-doc-nits script requires OpenSSL copyright in the doc pod files. This PR removes that check.