### PR TITLE
Fix duplicate ciphers in NTLS ClientHello

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,13 +7,11 @@ jobs:
     - name: Build Fuzzers
       uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
       with:
-        oss-fuzz-project-name: 'babassl'
         dry-run: false
         build-integration-path: fuzzer-build-integration
     - name: Run Fuzzers
       uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
       with:
-        oss-fuzz-project-name: 'babassl'
         fuzz-seconds: 600
         dry-run: false
         build-integration-path: fuzzer-build-integration

--- a/ssl/s3_lib.c
+++ b/ssl/s3_lib.c
@@ -3211,40 +3211,6 @@ static SSL_CIPHER ssl3_ciphers[] = {
 #endif /* OPENSSL_NO_ARIA */
 #if (!defined OPENSSL_NO_NTLS) && (!defined OPENSSL_NO_SM2)    \
      && (!defined OPENSSL_NO_SM3) && (!defined OPENSSL_NO_SM4)
-     /* BEGIN GM/T 0024-2014 cipher suites */
-    {
-     1,
-     NTLS_TXT_SM2DHE_WITH_SM4_SM3,
-     NULL,
-     NTLS_CK_ECDHE_SM2_SM4_CBC_SM3,
-     SSL_kSM2DHE,
-     SSL_aSM2,
-     SSL_SM4,
-     SSL_SM3,
-     NTLS_VERSION, NTLS_VERSION,
-     0, 0,
-     SSL_HIGH,
-     SSL_HANDSHAKE_MAC_SM3 | TLS1_PRF_SM3,
-     128,
-     128,
-     },
-    {
-     1,
-     NTLS_TXT_SM2_WITH_SM4_SM3,
-     NULL,
-     NTLS_CK_ECC_SM2_SM4_CBC_SM3,
-     SSL_kSM2,
-     SSL_aSM2,
-     SSL_SM4,
-     SSL_SM3,
-     NTLS_VERSION, NTLS_VERSION,
-     0, 0,
-     SSL_HIGH,
-     SSL_HANDSHAKE_MAC_SM3 | TLS1_PRF_SM3,
-     128,
-     128,
-     },
-     /* END GM/T 0024-2014 cipher suites */
     {
      1,
      NTLS_TXT_ECDHE_SM2_SM4_CBC_SM3,

--- a/ssl/ssl_ciph.c
+++ b/ssl/ssl_ciph.c
@@ -253,6 +253,12 @@ static const SSL_CIPHER cipher_aliases[] = {
      && (!defined OPENSSL_NO_SM3) && (!defined OPENSSL_NO_SM4)
     {0, SSL_TXT_kSM2, NULL, 0, SSL_kSM2},
     {0, SSL_TXT_kSM2DHE, NULL, 0, SSL_kSM2DHE},
+    {0, NTLS_TXT_SM2DHE_WITH_SM4_SM3, NULL, 0, SSL_kSM2DHE, SSL_aSM2, SSL_SM4,
+     SSL_SM3, NTLS_VERSION, NTLS_VERSION, 0, 0, SSL_HIGH,
+     SSL_HANDSHAKE_MAC_SM3 | TLS1_PRF_SM3, 128, 128},
+    {0, NTLS_TXT_SM2_WITH_SM4_SM3, NULL, 0, SSL_kSM2, SSL_aSM2, SSL_SM4,
+     SSL_SM3, NTLS_VERSION, NTLS_VERSION, 0, 0, SSL_HIGH,
+     SSL_HANDSHAKE_MAC_SM3 | TLS1_PRF_SM3, 128, 128},
 #endif
 
     /* server authentication aliases */


### PR DESCRIPTION
ECDHE-SM2-WITH-SM4-SM3 and ECC-SM2-WITH-SM4-SM3 should be
aliases of cipher ECDHE-SM2-SM4-CBC-SM3 and ECC-SM2-SM4-CBC-SM3.

Otherwise, there are two {0xE0, 0x11} or {0xE0, 0x13} ciphers in
NTLS ClientHello.