### PR TITLE
Release BabaSSL 8.2.1

### DIFF
--- a/CHANGES.BabaSSL
+++ b/CHANGES.BabaSSL
@@ -5,9 +5,17 @@
  This is a high-level summary of the most important changes.
  For a full list of changes, see the git commit log.
 
- Changes between 8.2.0 and 8.3.0 [xx XXX xxxx]
+ Changes between 8.2.1 and 8.2.2 [xx XXX xxxx]
 
   *)
+
+ Changes between 8.2.0 and 8.2.1 [27 Aug 2021]
+
+  *) Fix CVE-2021-3711
+
+  *) Fix CVE-2021-3712
+
+  *) Fix duplicated ciphers in NTLS ClientHello message
 
  Changes between 8.1.3 and 8.2.0 [19 May 2021]
 

--- a/include/openssl/opensslv.h
+++ b/include/openssl/opensslv.h
@@ -108,8 +108,8 @@ extern "C" {
  * 1.9.5          0x1090500f
  */
 
-# define BABASSL_VERSION_NUMBER  0x80200000L
-# define BABASSL_VERSION_TEXT    "BabaSSL 8.2.0-dev"
+# define BABASSL_VERSION_NUMBER  0x8020100fL
+# define BABASSL_VERSION_TEXT    "BabaSSL 8.2.1"
 
 #ifdef  __cplusplus
 }


### PR DESCRIPTION
*) Fix CVE-2021-3711

*) Fix CVE-2021-3712

*) Fix duplicated ciphers in NTLS ClientHello message