### PR TITLE
ssl/ntls: Sync NTLS extension defines with TLS

### DIFF
--- a/ssl/statem_ntls/extensions.c
+++ b/ssl/statem_ntls/extensions.c
@@ -140,7 +140,7 @@ static const EXTENSION_DEFINITION ext_defs[] = {
         tls_construct_stoc_maxfragmentlen_ntls, tls_construct_ctos_maxfragmentlen_ntls,
         final_maxfragmentlen
     },
-    INVALID_EXTENSION,
+    INVALID_EXTENSION, /* TLSEXT_TYPE_srp */
 # ifndef OPENSSL_NO_EC
     {
         TLSEXT_TYPE_ec_point_formats,
@@ -263,6 +263,7 @@ static const EXTENSION_DEFINITION ext_defs[] = {
 # else
     INVALID_EXTENSION,
 # endif
+    INVALID_EXTENSION, /* TLSEXT_TYPE_delegated_credential */
     {
         TLSEXT_TYPE_extended_master_secret,
         SSL_EXT_CLIENT_HELLO | SSL_EXT_TLS1_2_SERVER_HELLO
@@ -324,6 +325,8 @@ static const EXTENSION_DEFINITION ext_defs[] = {
         tls_construct_stoc_key_share_ntls, tls_construct_ctos_key_share_ntls,
         final_key_share
     },
+# else
+    INVALID_EXTENSION,
 # endif
     {
         /* Must be after key_share */
@@ -361,6 +364,8 @@ static const EXTENSION_DEFINITION ext_defs[] = {
         tls_construct_certificate_authorities,
         tls_construct_certificate_authorities, NULL,
     },
+    INVALID_EXTENSION, /* TLSEXT_TYPE_quic_transport_parameters_draft */
+    INVALID_EXTENSION, /* TLSEXT_TYPE_quic_transport_parameters */
     {
         /* Must be immediately before pre_shared_key */
         TLSEXT_TYPE_padding,


### PR DESCRIPTION
Add several missing `INVALID_EXTENSION` to the NTLS extension
defines (`ext_defs[]` array), making it consistent with TLS, i.e., same
number of extensions in the same order.

Without this fix, `tls_parse_extension_ntls()` and related functions may
fail because the `TLSEXT_IDX_*` and `TLSEXT_TYPE_*` don't match.