### PR TITLE
ssl/ntls: Don't change SM2 cert/key type during handshake

### DIFF
--- a/ssl/statem_ntls/statem_ntls_clnt.c
+++ b/ssl/statem_ntls/statem_ntls_clnt.c
@@ -793,7 +793,7 @@ int ntls_construct_cert_verify_ntls(SSL *s, WPACKET *pkt)
     }
 
     /* The only valid EC pkey in NTLS is SM2 */
-    if (EVP_PKEY_set_alias_type(pkey, EVP_PKEY_SM2) <= 0) {
+    if (EVP_PKEY_id(pkey) != EVP_PKEY_SM2) {
         SSLfatal_ntls(s, SSL_AD_INTERNAL_ERROR, SSL_F_NTLS_CONSTRUCT_CERT_VERIFY_NTLS,
                 ERR_R_EVP_LIB);
         goto err;

--- a/ssl/statem_ntls/statem_ntls_srvr.c
+++ b/ssl/statem_ntls/statem_ntls_srvr.c
@@ -133,7 +133,7 @@ static int ntls_construct_ske_sm2dhe(SSL *s, WPACKET *pkt)
         goto err;
     }
 
-    if (!EVP_PKEY_set_alias_type(pkey, EVP_PKEY_SM2)) {
+    if (EVP_PKEY_id(pkey) != EVP_PKEY_SM2) {
         SSLfatal_ntls(s, SSL_AD_INTERNAL_ERROR,
                  SSL_F_NTLS_CONSTRUCT_SKE_SM2DHE, ERR_R_EVP_LIB);
         goto err;
@@ -272,7 +272,7 @@ static int ntls_construct_ske_sm2(SSL *s, WPACKET *pkt)
         goto end;
     }
 
-    if (!EVP_PKEY_set_alias_type(pkey, EVP_PKEY_SM2)) {
+    if (EVP_PKEY_id(pkey) != EVP_PKEY_SM2) {
         SSLfatal_ntls(s, SSL_AD_INTERNAL_ERROR,
                  SSL_F_NTLS_CONSTRUCT_SKE_SM2, ERR_R_EVP_LIB);
         goto end;


### PR DESCRIPTION
Since the type of SM2 cert/key has already been correctly set upon its
loading [1], it's no longer needed to change the type during the
handshake.  So just check whether the cert/key type is correct.

[1] Commit 9cf287ca85ac48d33f2940c1e1159131511a4429 (s_server support
    multiple engines with different methods EVP_PKEY_set_alias_type for
    sm2 cert and key)