### PR TITLE
Do not allow dropping Extended Master Secret extension on renegotiaton

### DIFF
--- a/include/openssl/ssl3.h
+++ b/include/openssl/ssl3.h
@@ -292,6 +292,9 @@ extern "C" {
 
 # define TLS1_FLAGS_STATELESS                    0x0800
 
+/* Set if extended master secret extension required on renegotiation */
+# define TLS1_FLAGS_REQUIRED_EXTMS               0x1000
+
 # define SSL3_MT_HELLO_REQUEST                   0
 # define SSL3_MT_CLIENT_HELLO                    1
 # define SSL3_MT_SERVER_HELLO                    2

--- a/ssl/statem/extensions.c
+++ b/ssl/statem/extensions.c
@@ -1225,14 +1225,26 @@ static int init_etm(SSL *s, unsigned int context)
 
 static int init_ems(SSL *s, unsigned int context)
 {
-    if (!s->server)
+    if (s->s3->flags & TLS1_FLAGS_RECEIVED_EXTMS) {
         s->s3->flags &= ~TLS1_FLAGS_RECEIVED_EXTMS;
+        s->s3->flags |= TLS1_FLAGS_REQUIRED_EXTMS;
+    }
 
     return 1;
 }
 
 static int final_ems(SSL *s, unsigned int context, int sent)
 {
+    /*
+     * Check extended master secret extension is not dropped on
+     * renegotiation.
+     */
+    if (!(s->s3->flags & TLS1_FLAGS_RECEIVED_EXTMS)
+        && (s->s3->flags & TLS1_FLAGS_REQUIRED_EXTMS)) {
+        SSLfatal(s, SSL_AD_HANDSHAKE_FAILURE, SSL_F_FINAL_EMS,
+                 SSL_R_INCONSISTENT_EXTMS);
+        return 0;
+    }
     if (!s->server && s->hit) {
         /*
          * Check extended master secret extension is consistent with


### PR DESCRIPTION
Abort renegotiation if server receives client hello with Extended Master
Secret extension dropped in comparison to the initial session.

Fixes #9754

Reviewed-by: Matt Caswell <matt@openssl.org>
(Merged from https://github.com/openssl/openssl/pull/12045)

(cherry picked from commit 11d3235e2b5a1dc9f48c040b1f1b6bea86ffc745)
[Yilin: drop CHANGES.md and rebase babassl-8.2.1]

Signed-off-by: YiLin.Li <YiLin.Li@linux.alibaba.com>