### PR TITLE
Reorder SM4 ciphersuites

### DIFF
--- a/include/openssl/ssl.h
+++ b/include/openssl/ssl.h
@@ -209,8 +209,8 @@ extern "C" {
 
 # if (!defined OPENSSL_NO_SM2) && (!defined OPENSSL_NO_SM3) \
     && (!defined OPENSSL_NO_SM4)
-#  define SM4_CIPHERSUITES ":TLS_SM4_CCM_SM3" \
-                           ":TLS_SM4_GCM_SM3"
+#  define SM4_CIPHERSUITES ":TLS_SM4_GCM_SM3" \
+                           ":TLS_SM4_CCM_SM3"
 # else
 #  define SM4_CIPHERSUITES ""
 # endif

--- a/test/cipherlist_test.c
+++ b/test/cipherlist_test.c
@@ -71,8 +71,8 @@ static const uint32_t default_ciphers_in_order[] = {
 # endif
 # if (!defined OPENSSL_NO_SM2) && (!defined OPENSSL_NO_SM3) \
      && (!defined OPENSSL_NO_SM4)
-    TLS1_3_CK_SM4_CCM_SM3,
     TLS1_3_CK_SM4_GCM_SM3,
+    TLS1_3_CK_SM4_CCM_SM3,
 # endif
 #endif
 #ifndef OPENSSL_NO_TLS1_2

--- a/test/sslapitest.c
+++ b/test/sslapitest.c
@@ -5456,7 +5456,7 @@ static struct {
         "TLS_CHACHA20_POLY1305_SHA256:"
 # if !defined(OPENSSL_NO_SM2) && !defined(OPENSSL_NO_SM3) \
     && !defined(OPENSSL_NO_SM4)
-        "TLS_SM4_CCM_SM3:TLS_SM4_GCM_SM3:"
+        "TLS_SM4_GCM_SM3:TLS_SM4_CCM_SM3:"
 # endif
         "AES256-SHA"
     },


### PR DESCRIPTION
TLS_SM4_GCM_SM3 should be placed before TLS_SM4_CCM_SM3.