### PR TITLE
Fix egd and devrandom source configs

### DIFF
--- a/crypto/rand/rand_unix.c
+++ b/crypto/rand/rand_unix.c
@@ -409,7 +409,8 @@ static struct random_device {
 } random_devices[OSSL_NELEM(random_device_paths)];
 static int keep_random_devices_open = 1;
 
-#   if defined(__linux) && defined(DEVRANDOM_WAIT)
+#   if defined(__linux) && defined(DEVRANDOM_WAIT) \
+       && defined(OPENSSL_RAND_SEED_GETRANDOM)
 static void *shm_addr;
 
 static void cleanup_shm(void)
@@ -487,7 +488,7 @@ static int wait_random_seeded(void)
     }
     return seeded;
 }
-#   else /* defined __linux */
+#   else /* defined __linux && DEVRANDOM_WAIT && OPENSSL_RAND_SEED_GETRANDOM */
 static int wait_random_seeded(void)
 {
     return 1;


### PR DESCRIPTION
./config --with-rand-seed=egd

need to defines OPENSSL_RAND_SEED_EGD and OPENSSL_NO_EGD
so get rid of OPENSSL_NO_EGD (compiles but I did not really test EGD)

./config --with-rand-seed=devrandom

does not work since wait_random_seeded works under the assumption
that OPENSSL_RAND_SEED_GETRANDOM is supposed to be enabled as well,
that is usually the case, but not when only devrandom is enabled.
Skip the wait code in this special case.

Reviewed-by: Paul Dale <paul.dale@oracle.com>
(Merged from https://github.com/openssl/openssl/pull/11848)

(cherry picked from commit ddec332f329a432a45c0131d83f3bfb46114532b)