### PR TITLE
Export several macros of SM3 and SM3_CTX

### DIFF
--- a/include/crypto/sm3.h
+++ b/include/crypto/sm3.h
@@ -12,23 +12,15 @@
 # define OSSL_CRYPTO_SM3_H
 
 # include <openssl/opensslconf.h>
+# include <openssl/sm3.h>
 
 # ifdef OPENSSL_NO_SM3
 #  error SM3 is disabled.
 # endif
 
-# define SM3_DIGEST_LENGTH 32
-# define SM3_WORD unsigned int
-
-# define SM3_CBLOCK      64
-# define SM3_LBLOCK      (SM3_CBLOCK/4)
-
-typedef struct SM3state_st {
-   SM3_WORD A, B, C, D, E, F, G, H;
-   SM3_WORD Nl, Nh;
-   SM3_WORD data[SM3_LBLOCK];
-   unsigned int num;
-} SM3_CTX;
+# ifdef  __cplusplus
+extern "C" {
+# endif
 
 int sm3_init(SM3_CTX *c);
 int sm3_update(SM3_CTX *c, const void *data, size_t len);
@@ -36,4 +28,7 @@ int sm3_final(unsigned char *md, SM3_CTX *c);
 
 void sm3_block_data_order(SM3_CTX *c, const void *p, size_t num);
 
+# ifdef  __cplusplus
+}
+# endif
 #endif

--- a/include/openssl/sm3.h
+++ b/include/openssl/sm3.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 The BabaSSL Project Authors. All Rights Reserved.
+ *
+ * Licensed under the BabaSSL license (the "License").  You may not use
+ * this file except in compliance with the License.  You can obtain a copy
+ * in the file LICENSE in the source distribution or at
+ * https://github.com/BabaSSL/BabaSSL/blob/master/LICENSE
+ */
+
+#ifndef HEADER_SM3_H
+# define HEADER_SM3_H
+
+# include <openssl/opensslconf.h>
+
+# ifndef OPENSSL_NO_SM3
+#  ifdef  __cplusplus
+extern "C" {
+#  endif
+
+#  define SM3_DIGEST_LENGTH 32
+#  define SM3_WORD unsigned int
+
+#  define SM3_CBLOCK      64
+#  define SM3_LBLOCK      (SM3_CBLOCK/4)
+
+typedef struct SM3state_st {
+   SM3_WORD A, B, C, D, E, F, G, H;
+   SM3_WORD Nl, Nh;
+   SM3_WORD data[SM3_LBLOCK];
+   unsigned int num;
+} SM3_CTX;
+
+#  ifdef  __cplusplus
+}
+#  endif
+# endif
+#endif


### PR DESCRIPTION
These macros and struct are required to implement the SM3 algorithm in the engine