### PR TITLE
Synchronize bug fixes from master to 8.3-stable

### DIFF
--- a/CHANGES.BabaSSL
+++ b/CHANGES.BabaSSL
@@ -7,9 +7,11 @@
 
  Changes between 8.3.0 and 8.3.1 [xx XXX xxxx]
 
-  *) Fix CVE-2022-0778
-
   *)
+
+  *) Fix bugs in SM2 implementation [0x9527-zhou]
+
+  *) Fix CVE-2022-0778
 
  Changes between 8.2.0 and 8.3.0 [28 Feb 2022]
 

--- a/crypto/sm2/sm2_sign.c
+++ b/crypto/sm2/sm2_sign.c
@@ -425,6 +425,10 @@ int sm2_sign(const unsigned char *dgst, int dgstlen,
     }
 
     s = sm2_sig_gen(eckey, e);
+    if (s == NULL) {
+       SM2err(SM2_F_SM2_SIGN, ERR_R_INTERNAL_ERROR);
+       goto done;
+    }
 
     sigleni = i2d_ECDSA_SIG(s, &sig);
     if (sigleni < 0) {

--- a/crypto/sm2/sm2_sign.c
+++ b/crypto/sm2/sm2_sign.c
@@ -261,6 +261,10 @@ static ECDSA_SIG *sm2_sig_gen(const EC_KEY *key, const BIGNUM *e)
             goto done;
         }
 
+        /* try again if s == 0 */
+        if (BN_is_zero(s))
+            continue;
+
         sig = ECDSA_SIG_new();
         if (sig == NULL) {
             SM2err(SM2_F_SM2_SIG_GEN, ERR_R_MALLOC_FAILURE);


### PR DESCRIPTION
Two fixes #212 and #213 are included in this PR, as well as update on CHANGES.BabaSSL